### PR TITLE
erase pid from map on logout or if dinit terms prematurely

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -189,6 +189,13 @@ void reap_child(int sig) {
         char buffer[64];
         int len = snprintf(buffer, sizeof(buffer), "[LOG] Reaped child PID: %d\n", (int)pid);
         write(STDOUT_FILENO, buffer, len);
+        // Prune map so stale PIDs don't linger if dinit exited before logout
+        for (auto it = uid_pid_map.begin(); it != uid_pid_map.end(); ++it) {
+            if (it->second == pid) {
+                uid_pid_map.erase(it);
+                break;
+            }
+        }
     }
 }
 
@@ -289,8 +296,10 @@ int main() {
                     if (event->mask & IN_CREATE) {
                         handle_user(parsed_name.value());
                     } else if (event->mask & IN_DELETE) {
-                        if (uid_pid_map.find(parsed_name.value()) != uid_pid_map.end()) {
-                            kill(uid_pid_map.at(parsed_name.value()), SIGTERM);
+                        auto it = uid_pid_map.find(parsed_name.value());
+                        if (it != uid_pid_map.end()) {
+                            kill(it->second, SIGTERM);
+                            uid_pid_map.erase(it);
                             std::cout << "[LOG] Cleaning up UID: " << parsed_name.value() << std::endl;
                         } else {
                             std::cerr << "[ERROR] Tried to clean up after UID: " << parsed_name.value() << " but failed to find matching PID!" << std::endl; 


### PR DESCRIPTION
This fixes an issue where on any login/logout cycle after the second one since OS start, the user dinit instance wasn't getting sigtermed, even though elogind would close the session (and remove /run/user/xxxx which would normally trigger dinit-user-spawn to sigterm the user's dinit). On the first logout, dinit-user-spawn would correctly sigterm the user dinit pid, but wouldn't remove the pid from the map. The second login would still properly launch a user dinit instance, but silently fail adding the 2nd pid to the map since the old value wasn't erased. Then on 2nd logout, dinit-user-spawn would try to sigterm the pid of the first dinit user instance (which no longer exists) and not the second (or any thereafter). This should also fix stale pids getting stuck in the map if dinit terms before the user logs out.

This was reported by some users in a thread on the Artix forums, in terms of having issues getting user services to launch on login after logout, and I also personally experienced it on several Artix w/ dinit installs.
https://forum.artixlinux.org/index.php/topic,9583.msg57290.html#msg57290
https://forum.artixlinux.org/index.php/topic,9583.msg57363.html#msg57363